### PR TITLE
fix compilation & segv on exit

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -742,7 +742,7 @@ input_destroy_notify(struct wl_listener *listener, void *data)
          if(test_input==input) continue;
          if(test_input->device->type==WLR_INPUT_DEVICE_KEYBOARD) break;
       }
-      if(test_input)
+      if(test_input && test_input->keyboard->keymap_string != 0x0)
          wlr_seat_set_keyboard(g_server->seat, test_input->keyboard);
    }
    wl_list_remove(&input->destroy.link);

--- a/src/server.c
+++ b/src/server.c
@@ -533,12 +533,12 @@ startServer()
 
    const char* socket = wl_display_add_socket_auto(g_server->display);
    if(!socket){
-      cleanupServer(g_server);
+      cleanupServer();
       say(ERROR, "Unable to add socket to Wayland display!");
    }
 
    if(!wlr_backend_start(g_server->backend)){
-      cleanupServer(g_server);
+      cleanupServer();
       say(ERROR, "Unable to start WLR backend!");
    }
    


### PR DESCRIPTION
Two changes:

in startServer, cleanupServer is called with an argument: g_server.
the definition of cleanupServer does not allow it to be called with an argument, causing a compilation error with my installation (gcc 15.2.1).

The commit 6046cb467434cd814a00f16bb02b062b949b59d5 added a way to avoid a SEGV when unplugging a keyboard.

However, this call to wlr_seat_set_keyboard ends in a segfault when exiting simplewc. 

SEGV backtrace:

```
libwayland-server.so.0!wl_list_insert(struct wl_list * list, struct wl_list * elm, struct wl_list * elm@entry) (~/.cache/debuginfod_client/243379cfd8cc991c31248defae51c14a2452cf43/source-cdc96f40-#usr#src#debug#wayland-1.24.0-1.fc42.x86_64#redhat-linux-build#..#src#wayland-util.c:47)
libwlroots-0.19.so!wl_signal_add(struct wl_signal * signal, struct wl_listener * listener) (/usr/include/wayland-server-core.h:476)
libwlroots-0.19.so!wlr_seat_set_keyboard(struct wlr_seat * seat, struct wlr_keyboard * keyboard) (~/docs/projects/wlroots/types/seat/wlr_seat_keyboard.c:143)
input_destroy_notify(struct wl_listener * listener, void * data) (~/docs/projects/wlroots/simplewc/src/input.c:746)
libwayland-server.so.0!wl_signal_emit_mutable(struct wl_signal * signal, struct wl_signal * signal@entry, void * data, void * data@entry) (~/.cache/debuginfod_client/243379cfd8cc991c31248defae51c14a2452cf43/source-2086d7d9-#usr#src#debug#wayland-1.24.0-1.fc42.x86_64#redhat-linux-build#..#src#wayland-server.c:2369)
libwlroots-0.19.so!wlr_input_device_finish(struct wlr_input_device * wlr_device, struct wlr_input_device * wlr_device@entry) (~/docs/projects/wlroots/types/wlr_input_device.c:21)
libwlroots-0.19.so!wlr_keyboard_finish(struct wlr_keyboard * kb) (~/docs/projects/wlroots/types/wlr_keyboard.c:168)
libwlroots-0.19.so!destroy_wl_seat(struct wlr_wl_seat * seat) (~/docs/projects/wlroots/backend/wayland/seat.c:288)
libwlroots-0.19.so!backend_destroy(struct wlr_backend * backend) (~/docs/projects/wlroots/backend/wayland/backend.c:509)
libwlroots-0.19.so!multi_backend_destroy(struct wlr_backend * wlr_backend) (~/docs/projects/wlroots/backend/multi/backend.c:62)
cleanupServer() (~/docs/projects/wlroots/simplewc/src/server.c:604)
main(int argc, char ** argv) (~/docs/projects/wlroots/simplewc/src/main.c:181)
```

I am not 100% certain checking for keymap_string's non-NULL status is a great way to prevent the segmentation fault. 

However, it prevents it on my machine and I don't often unplug my keyboard 